### PR TITLE
Fix package.json exports and add missing readCaptionSpecification action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manucap",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manucap",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "dependencies": {
         "@mdi/js": "^7.4.47",
         "@mdi/react": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,19 @@
     "type": "git",
     "url": "https://github.com/lkrnac/manucap"
   },
-  "main": "dist/index.js",
-  "types": "dist/@types/index.d.ts",
+  "main": "dist/manucap.js",
+  "module": "dist/manucap.mjs",
+  "types": "dist/indexLibrary.d.ts",
+  "style": "dist/manucap.css",
+  "exports": {
+    ".": {
+      "import": "./dist/manucap.mjs",
+      "require": "./dist/manucap.js",
+      "types": "./dist/indexLibrary.d.ts"
+    },
+    "./style": "./dist/manucap.css",
+    "./dist/manucap.css": "./dist/manucap.css"
+  },
   "engines": {
     "node": ">=24",
     "npm": ">=11"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manucap",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "",
   "license": "",
   "repository": {

--- a/src/indexLibrary.ts
+++ b/src/indexLibrary.ts
@@ -6,12 +6,14 @@ import VideoPlayer from "./manucap/player/VideoPlayer";
 import useMatchedCuesAsCsv from "./manucap/cues/cuesList/useMatchedCuesAsCsv";
 import { updateSourceCues } from "./manucap/cues/view/sourceCueSlices";
 import { updateCaptionUser } from "./manucap/userSlices";
+import { readCaptionSpecification } from "./manucap/toolbox/captionSpecifications/captionSpecificationSlice";
 
 const Actions = ({
     updateEditingTrack,
     updateCues,
     updateSourceCues,
     updateCaptionUser,
+    readCaptionSpecification,
 });
 
 const Hooks = ({


### PR DESCRIPTION
## Summary

- Fix `main` and `types` fields pointing to non-existent dist paths (`dist/index.js`, `dist/@types/index.d.ts`) — actual built files are `dist/manucap.js` and `dist/indexLibrary.d.ts`
- Add `module` field pointing to `dist/manucap.mjs` for ESM consumers
- Add `style` field and `exports` map so consumers can import CSS directly via `import 'manucap/style'`
- Export `readCaptionSpecification` from `Actions` in `indexLibrary.ts`

Fixes the need for manual workarounds in consuming projects (`manucap.d.ts` and `manucap.css` hacks).

After this change consumers can simply do:
```ts
import { ManuCap, Actions, Reducers, VideoPlayer, Hooks } from 'manucap';
import 'manucap/style';
```

## Test plan
- [ ] Build the library (`npm run build`) and verify `dist/manucap.js`, `dist/manucap.mjs`, `dist/manucap.css`, `dist/indexLibrary.d.ts` are present
- [ ] Install the new package in the consuming project and remove `manucap.d.ts` and `manucap.css` workarounds
- [ ] Verify TypeScript types resolve correctly without the manual declaration file
- [ ] Verify CSS applies correctly when imported via `import 'manucap/style'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)