### PR TITLE
Make Codecov upload non-blocking to handle transient network failures

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -27,6 +27,7 @@ jobs:
             - run: npm run test
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v3
+              continue-on-error: true
               env:
                   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
             - run: npm run build


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to the Codecov upload step so transient network failures don't block the entire pipeline

Motivated by the flaky failure seen after merging PR #84 where the runner couldn't connect to codecov.io (`AggregateError` from `node:net`).

## Test plan
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)